### PR TITLE
Add pr-ready skill and PR template

### DIFF
--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pr-ready
+description: Prepare and open a pull request with a well-written body based on the PR template. Use this skill whenever the developer wants to open a PR, create a pull request, push and create a PR, or is done with a feature and wants to submit it for review. Trigger when the user mentions "pr ready", "open a PR", "create PR", "submit PR", "push and create PR", "ready for review", "open pull request", or any variation of preparing a branch for pull request submission.
+---
+
+You are a Pull Request preparation agent for the Giveth Blockchain Integration Service repository (`Giveth/Blockchain-integration-service`). Your job is to help the developer open a clean, well-documented pull request targeting `staging`.
+
+## Step 1 — Verify Branch
+
+Before anything else, check the current branch. If the developer is on `staging` or `main`, stop and tell them:
+
+> You're on `<branch-name>`. Please create a feature branch first before opening a PR.
+
+Do not proceed until the developer is on a feature branch.
+
+## Step 2 — Check for Uncommitted Changes
+
+Check the working tree status. Look for staged, unstaged, and untracked files.
+
+If there are uncommitted changes, list them and tell the developer:
+
+> You have uncommitted changes:
+>
+> - `<file>` (modified/staged/untracked)
+>
+> Please commit your changes first, or tell me to proceed anyway (uncommitted files will NOT be included in the PR).
+
+If the developer says to proceed, continue with only the committed code. If they want to commit first, stop and let them handle it.
+
+If the working tree is clean, proceed.
+
+## Step 3 — Resolve the Issue
+
+You need the GitHub issue to write a good PR body. Try these approaches in order:
+
+### 3a. User provided input directly
+
+If the user passed an argument (issue number, URL, or pasted text), use that:
+
+- `#123` or `123` → fetch from GitHub
+- `https://github.com/Giveth/Blockchain-integration-service/issues/123` → extract number, fetch from GitHub
+- Pasted text block → use directly as the issue content
+
+### 3b. Extract from branch name
+
+Run `git branch --show-current` and look for a number pattern (e.g. `feat/123-description`, `fix/GIV-123-description`). If found, fetch the issue from GitHub.
+
+### 3c. Ask the developer
+
+If you cannot determine the issue, ask:
+
+> I couldn't find an issue number in your branch name. Please provide one of:
+>
+> - Issue number (e.g. `123`)
+> - Issue URL (e.g. `https://github.com/Giveth/Blockchain-integration-service/issues/123`)
+> - Or paste the issue description as text
+
+### How to fetch the issue
+
+Use whatever GitHub tools are available to you — MCP tools, `gh` CLI, etc. The repository is `Giveth/Blockchain-integration-service`.
+
+## Step 4 — Gather the Diff
+
+Get the committed changes on this branch compared to `staging`:
+
+```bash
+git diff staging...HEAD
+```
+
+If `staging` doesn't exist locally, use `origin/staging`. Read the diff to understand what was changed, added, or removed.
+
+## Step 5 — Fill the PR Template
+
+Read the PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in each section:
+
+- **Issue**: `#<number>` from Step 3. Do NOT use `Closes` or `Fixes` — just the reference. If the issue was provided as pasted text with no number, leave this section empty for the developer to fill in during review.
+- **Summary**: 2-3 sentences explaining what this PR does and why, based on the issue description and the diff. Focus on the motivation, not a list of files.
+- **Changes**: Bullet list of concrete changes derived from the diff. Group logically (e.g. "Added Safe transaction verification endpoint", "Updated chain configuration for new network support"). Not a file-by-file list — describe what was done at a meaningful level.
+- **How to Test**: Step-by-step manual verification instructions. Infer from the issue's acceptance criteria and the changes. Be specific: endpoints to call, payloads to send, expected responses. Include sample `curl` commands when applicable.
+
+## Step 6 — Review with Developer
+
+Show the filled PR body to the developer. Ask:
+
+> Here's the PR I'll create. Review it and let me know if you want to change anything, or confirm to proceed.
+
+Wait for their confirmation or edits. Apply any changes they request.
+
+## Step 7 — Push and Open the PR
+
+After the developer confirms:
+
+1. Push the branch to origin (with `-u` to set upstream tracking if needed)
+2. Create the PR targeting `staging` using whatever GitHub tools are available
+
+Show the developer the PR URL when done.
+
+## Important Guidelines
+
+- Never use `Closes`, `Fixes`, or `Resolves` in the issue reference — just `#<number>`. The team has separate pipeline steps for closing issues.
+- The "How to Test" section is a draft for the developer to review — flag it as something they should verify and adjust.
+- Keep the summary concise — the issue link provides full context.
+- Read the project's `CLAUDE.md` for any PR conventions or standards.

--- a/.codex/skills/pr-ready
+++ b/.codex/skills/pr-ready
@@ -1,0 +1,1 @@
+../../.claude/skills/pr-ready

--- a/.cursor/skills/pr-ready
+++ b/.cursor/skills/pr-ready
@@ -1,0 +1,1 @@
+../../.claude/skills/pr-ready

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Issue
+
+#
+
+## Summary
+
+## Changes
+
+-
+
+## How to Test
+
+1.


### PR DESCRIPTION
## Issue

_(No linked issue)_

## Summary

Adds a `pr-ready` AI skill and a GitHub PR template to standardize pull request creation. The skill guides developers through preparing well-documented PRs by auto-filling the template with issue context, diff analysis, and testing instructions.

## Changes

- Added `.claude/skills/pr-ready/SKILL.md` — AI skill that walks through branch verification, uncommitted change detection, issue resolution, diff gathering, and PR creation
- Added `.github/PULL_REQUEST_TEMPLATE.md` — standardized PR template with Issue, Summary, Changes, and How to Test sections
- Added symlinks at `.codex/skills/pr-ready` and `.cursor/skills/pr-ready` for cross-tool compatibility

## How to Test

1. Check out this branch and run `/pr-ready` in Claude Code (or equivalent AI tool) on a feature branch with committed changes
2. Verify the skill detects the current branch, checks for uncommitted changes, and attempts to resolve a linked issue
3. Confirm the PR template is rendered when creating a new PR on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PR preparation workflow that guides developers through opening pull requests to the staging branch, including git verification, issue linking, and diff gathering.
  * Introduced a standardized GitHub pull request template with sections for Issue, Summary, Changes, and How to Test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->