### PR TITLE
Support GIV price lookup for GIVbacks flow

### DIFF
--- a/docs/EXTERNAL-SERVICES.md
+++ b/docs/EXTERNAL-SERVICES.md
@@ -35,7 +35,7 @@
 
 ---
 
-## Consumer
+## Consumers
 
 ### giveth-v6-core
 
@@ -44,6 +44,15 @@ The only direct consumer. v6-core proxies all blockchain interaction through thi
 - **Their client code:** `giveth-v6-core/src/integrations/blockchain/blockchain.service.ts`
 - **Endpoints actively consumed:** `POST /api/verify`, `POST /api/timestamp`, `POST /api/price`, `GET /api/chains`, `GET /api/chains/:networkId/transaction-url/:txHash`
 - **Endpoint wired but not yet called:** `POST /api/verify-batch` (client method exists in v6-core but no call site uses it)
+
+### GIVeconomy-service
+
+GIVeconomy-service now uses this service as its live GIV price source for the GIVbacks monthly-panel calculation.
+
+- **Their service code:** `GIVeconomy-service/src/services/tokenPriceService.ts`
+- **Endpoint actively consumed:** `POST /api/price`
+- **Current request shape:** `networkId: 1`, `symbol: 'GIV'`
+- **Why:** centralize token-price lookup logic here instead of duplicating CoinGecko / CryptoCompare access in GIVeconomy.
 
 ---
 
@@ -66,6 +75,7 @@ Direct connection via `@solana/web3.js` for parsing Solana transactions and calc
 Token price lookups in USD by symbol or contract address. Results cached in-memory (1-min TTL).
 
 - **Source:** `src/services/priceService.ts`
+- **Extra detail:** the symbol lookup path now includes selected well-known non-native tokens such as `GIV`, so downstream services can request GIV/USD with the same `/api/price` contract they already use for native tokens.
 
 ### Safe API (Gnosis Safe)
 

--- a/src/services/priceService.test.ts
+++ b/src/services/priceService.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import axios from 'axios';
+import { priceService } from './priceService';
+
+describe('PriceService', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getTokenPrice', () => {
+    it('uses the GIV symbol mapping for direct price lookup', async () => {
+      const axiosGetStub = sinon.stub(axios, 'get').resolves({
+        data: {
+          giveth: {
+            usd: 0.055,
+          },
+        },
+      });
+
+      const result = await priceService.getTokenPrice({
+        networkId: 1,
+        symbol: 'GIV',
+      });
+
+      expect(result).to.equal(0.055);
+      sinon.assert.calledOnceWithExactly(
+        axiosGetStub,
+        'https://api.coingecko.com/api/v3/simple/price?ids=giveth&vs_currencies=usd',
+        { timeout: 10000 },
+      );
+    });
+
+    it('uses contract address lookup when tokenAddress is provided', async () => {
+      const tokenAddress = '0x1234567890abcdef1234567890abcdef12345678';
+      const axiosGetStub = sinon.stub(axios, 'get').resolves({
+        data: {
+          [tokenAddress.toLowerCase()]: {
+            usd: 1.23,
+          },
+        },
+      });
+
+      const result = await priceService.getTokenPrice({
+        networkId: 1,
+        symbol: 'TEST',
+        tokenAddress,
+      });
+
+      expect(result).to.equal(1.23);
+      sinon.assert.calledOnceWithExactly(
+        axiosGetStub,
+        `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress.toLowerCase()}&vs_currencies=usd`,
+        { timeout: 10000 },
+      );
+    });
+  });
+});

--- a/src/services/priceService.ts
+++ b/src/services/priceService.ts
@@ -16,8 +16,8 @@ const COINGECKO_PLATFORM_IDS: Record<number, string> = {
   101: 'solana',
 };
 
-// Native token CoinGecko IDs
-const NATIVE_TOKEN_IDS: Record<string, string> = {
+// Symbol-based CoinGecko IDs for native tokens and selected known ERC-20s.
+const SYMBOL_TOKEN_IDS: Record<string, string> = {
   ETH: 'ethereum',
   MATIC: 'polygon-ecosystem-token', // MATIC was rebranded to POL
   POL: 'polygon-ecosystem-token',
@@ -27,6 +27,7 @@ const NATIVE_TOKEN_IDS: Record<string, string> = {
   XDAI: 'xdai', // Native token on Gnosis Chain
   DAI: 'dai',
   SOL: 'solana',
+  GIV: 'giveth',
 };
 
 export class PriceService {
@@ -110,10 +111,10 @@ export class PriceService {
   }
 
   private async getPriceBySymbol(symbol: string): Promise<number> {
-    const coinId = NATIVE_TOKEN_IDS[symbol.toUpperCase()];
+    const coinId = SYMBOL_TOKEN_IDS[symbol.toUpperCase()];
 
     if (!coinId) {
-      logger.warn('Unknown native token symbol', { symbol });
+      logger.warn('Unknown symbol for direct price lookup', { symbol });
       return 0;
     }
 


### PR DESCRIPTION
## Issue

https://github.com/Giveth/giveth-v6-core/issues/72

## Summary

This PR extends the blockchain integration price service so downstream services can request a live USD price for `GIV` through the existing `/api/price` contract. That keeps GIV price lookup centralized here and supports the new GIVbacks monthly-panel backend flow implemented in the paired core and GIVeconomy PRs.

## Changes

- Added `GIV` to the symbol-based CoinGecko price lookup map in `priceService`.
- Kept the existing `/api/price` route contract unchanged while enabling `networkId: 1, symbol: 'GIV'` requests.
- Added service-level test coverage for direct `GIV` price lookup and documented the new downstream `GIVeconomy-service` consumer in `docs/EXTERNAL-SERVICES.md`.

## How to Test

1. Run `npm test -- --grep "PriceService|POST /api/price"`.
2. Run `npm run build`.
3. Start the service locally.
4. Send:
   ```bash
   curl -X POST http://localhost:3001/api/price \
     -H 'Content-Type: application/json' \
     -d '{"networkId":1,"symbol":"GIV"}'
   ```
5. Confirm the response returns `success: true` and a non-negative `priceUsd` for `GIV`.
6. If the paired `GIVeconomy-service` branch is running, verify its current-round GIVbacks endpoint can now resolve GIV price through this service without needing local price-provider logic.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/api/price` endpoint now supports symbol-based price requests for known tokens, including GIV, enabling additional services to request token prices through the same API contract.

* **Documentation**
  * Updated external services documentation to reflect new consumers and clarify that the symbol lookup path now includes well-known non-native tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->