### PR TITLE
Add FINN fixed-price override in price service

### DIFF
--- a/src/services/priceService.test.ts
+++ b/src/services/priceService.test.ts
@@ -1,16 +1,28 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import axios from 'axios';
-import { priceService } from './priceService';
+import { FINN_MOCK_ADDRESS_MAINNET, PriceService } from './priceService';
 
-describe('PriceService', () => {
+describe('PriceService - FINN fixed-price override', () => {
+  let axiosGetStub: sinon.SinonStub;
+  let priceService: PriceService;
+
+  const ETH_COINGECKO_URL =
+    'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd';
+
+  beforeEach(() => {
+    axiosGetStub = sinon.stub(axios, 'get');
+    // Fresh instance per test to avoid cross-test cache pollution.
+    priceService = new PriceService();
+  });
+
   afterEach(() => {
     sinon.restore();
   });
 
   describe('getTokenPrice', () => {
     it('uses the GIV symbol mapping for direct price lookup', async () => {
-      const axiosGetStub = sinon.stub(axios, 'get').resolves({
+      axiosGetStub.resolves({
         data: {
           giveth: {
             usd: 0.055,
@@ -33,7 +45,7 @@ describe('PriceService', () => {
 
     it('uses contract address lookup when tokenAddress is provided', async () => {
       const tokenAddress = '0x1234567890abcdef1234567890abcdef12345678';
-      const axiosGetStub = sinon.stub(axios, 'get').resolves({
+      axiosGetStub.resolves({
         data: {
           [tokenAddress.toLowerCase()]: {
             usd: 1.23,
@@ -54,5 +66,96 @@ describe('PriceService', () => {
         { timeout: 10000 },
       );
     });
+  });
+
+  it('returns 0.001 * ETH USD price for FINN at the mock mainnet address', async () => {
+    axiosGetStub.withArgs(ETH_COINGECKO_URL, sinon.match.any).resolves({
+      data: { ethereum: { usd: 2500 } },
+    });
+
+    const price = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'FINN',
+      tokenAddress: FINN_MOCK_ADDRESS_MAINNET,
+    });
+
+    expect(price).to.equal(2.5);
+    expect(axiosGetStub.calledOnce).to.be.true;
+    expect(axiosGetStub.firstCall.args[0]).to.equal(ETH_COINGECKO_URL);
+  });
+
+  it('matches the FINN override case-insensitively on the address', async () => {
+    axiosGetStub.withArgs(ETH_COINGECKO_URL, sinon.match.any).resolves({
+      data: { ethereum: { usd: 3000 } },
+    });
+
+    const price = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'FINN',
+      tokenAddress: FINN_MOCK_ADDRESS_MAINNET.toUpperCase(),
+    });
+
+    expect(price).to.equal(3);
+    expect(axiosGetStub.calledOnce).to.be.true;
+    expect(axiosGetStub.firstCall.args[0]).to.equal(ETH_COINGECKO_URL);
+  });
+
+  it('does not hit the CoinGecko token_price endpoint for FINN', async () => {
+    axiosGetStub.withArgs(ETH_COINGECKO_URL, sinon.match.any).resolves({
+      data: { ethereum: { usd: 2000 } },
+    });
+
+    await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'FINN',
+      tokenAddress: FINN_MOCK_ADDRESS_MAINNET,
+    });
+
+    const calledUrls = axiosGetStub.getCalls().map((c) => c.args[0]);
+    expect(calledUrls).to.have.lengthOf(1);
+    expect(calledUrls[0]).to.not.include('/simple/token_price/');
+  });
+
+  it('caches the derived FINN price within the TTL', async () => {
+    axiosGetStub.withArgs(ETH_COINGECKO_URL, sinon.match.any).resolves({
+      data: { ethereum: { usd: 2500 } },
+    });
+
+    const first = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'FINN',
+      tokenAddress: FINN_MOCK_ADDRESS_MAINNET,
+    });
+    const second = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'FINN',
+      tokenAddress: FINN_MOCK_ADDRESS_MAINNET,
+    });
+
+    expect(first).to.equal(2.5);
+    expect(second).to.equal(2.5);
+    expect(axiosGetStub.calledOnce).to.be.true;
+  });
+
+  it('still routes non-FINN ERC-20 tokens through the CoinGecko token_price endpoint', async () => {
+    const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    axiosGetStub.resolves({
+      data: { [usdcAddress.toLowerCase()]: { usd: 1 } },
+    });
+
+    const price = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'USDC',
+      tokenAddress: usdcAddress,
+    });
+
+    expect(price).to.equal(1);
+    expect(axiosGetStub.calledOnce).to.be.true;
+    expect(axiosGetStub.firstCall.args[0]).to.include(
+      '/simple/token_price/ethereum',
+    );
+    expect(axiosGetStub.firstCall.args[0]).to.include(
+      usdcAddress.toLowerCase(),
+    );
   });
 });

--- a/src/services/priceService.ts
+++ b/src/services/priceService.ts
@@ -32,7 +32,7 @@ const SYMBOL_TOKEN_IDS: Record<string, string> = {
 
 // TODO: Replace with the real FINN mainnet address once deployed.
 export const FINN_MOCK_ADDRESS_MAINNET =
-  '0x000000000000000000000000000000000000f199'.toLowerCase();
+  '0xb87c3637Eb7C28AaC2C918ED8EC0C3b3b5e8fB67'.toLowerCase();
 
 type FixedPriceEntry = { kind: 'ratio'; baseSymbol: string; ratio: number };
 

--- a/src/services/priceService.ts
+++ b/src/services/priceService.ts
@@ -30,6 +30,22 @@ const SYMBOL_TOKEN_IDS: Record<string, string> = {
   GIV: 'giveth',
 };
 
+// TODO: Replace with the real FINN mainnet address once deployed.
+export const FINN_MOCK_ADDRESS_MAINNET =
+  '0x000000000000000000000000000000000000f199'.toLowerCase();
+
+type FixedPriceEntry = { kind: 'ratio'; baseSymbol: string; ratio: number };
+
+// Tokens whose USD price is derived from another token's price at a fixed
+// ratio. Keyed by `${networkId}:${lowercasedAddress}`.
+const FIXED_PRICE_TOKENS: Record<string, FixedPriceEntry> = {
+  [`1:${FINN_MOCK_ADDRESS_MAINNET}`]: {
+    kind: 'ratio',
+    baseSymbol: 'ETH',
+    ratio: 0.001,
+  },
+};
+
 export class PriceService {
   private readonly coingeckoBaseUrl = 'https://api.coingecko.com/api/v3';
   private priceCache: Map<string, { price: number; timestamp: number }> =
@@ -84,7 +100,14 @@ export class PriceService {
     try {
       let price: number;
 
-      if (tokenAddress) {
+      const fixedEntry = tokenAddress
+        ? FIXED_PRICE_TOKENS[`${networkId}:${tokenAddress.toLowerCase()}`]
+        : undefined;
+
+      if (fixedEntry) {
+        const basePrice = await this.getPriceBySymbol(fixedEntry.baseSymbol);
+        price = basePrice * fixedEntry.ratio;
+      } else if (tokenAddress) {
         // Get price by contract address
         price = await this.getPriceByContractAddress(networkId, tokenAddress);
       } else {


### PR DESCRIPTION
## Issue

Giveth/giveth-v6-core#191

## Summary

Adds backend price support for the new ETHSecurity Donation Finneys (`FINN`) token so donations made in FINN get valued at `0.001 × ETH_USD` per token, per the rounds requirement. Price resolution is now pluggable via a fixed-price override table keyed by `networkId:tokenAddress`, which keeps non-FINN tokens on the existing CoinGecko path.

## Changes

- Introduced a `FIXED_PRICE_TOKENS` map in `priceService.ts` that derives a token's USD price from another token at a fixed ratio (`{ kind: 'ratio', baseSymbol, ratio }`).
- Registered FINN on Ethereum mainnet with `baseSymbol: 'ETH'` and `ratio: 0.001`, and exported a placeholder `FINN_MOCK_ADDRESS_MAINNET` to be swapped for the real deployment address.
- Updated `PriceService.getTokenPrice` to check the fixed-price override (case-insensitive on address) before falling back to contract-address or symbol lookups, and to cache the derived price like any other lookup.
- Added unit tests covering: FINN returns `ETH × 0.001`, case-insensitive address match, no extra call to CoinGecko's `/simple/token_price/` endpoint, TTL cache hit on repeat lookups, and that non-FINN ERC-20s still flow through the token_price endpoint.

> ⚠️ Follow-up before merging: replace `FINN_MOCK_ADDRESS_MAINNET` (`src/services/priceService.ts`) with the real deployed FINN mainnet address.

## How to Test

> Draft — please review and adjust before merging.

1. `npm ci`
2. `npm test -- --grep "PriceService - FINN fixed-price override"` — all five specs should pass.
3. Full suite: `npm test` — should remain green.
4. Manual sanity check with the server running locally (`npm run dev`):
   - Call the price endpoint with `networkId=1`, `symbol=FINN`, `tokenAddress=0x000000000000000000000000000000000000f199` and confirm the returned price is ≈ `0.001 × current ETH/USD`.
   - Repeat within the cache TTL (1 min) and confirm no additional outbound CoinGecko request for ETH is fired.
5. Before shipping: replace the placeholder address with the real deployed FINN mainnet address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FINN token now uses a fixed-price override derived from the ETH/USD price, matched case-insensitively, so FINN prices are consistent and avoid the generic token-price endpoint; pricing is cached to minimize external API calls.
* **Tests**
  * Expanded test coverage to validate FINN override behavior, case-insensitive matching, fallback for other tokens, and caching to ensure reduced API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->