### PR TITLE
Prioritize AA donation verification

### DIFF
--- a/src/services/chains/evm/evmTransactionService.test.ts
+++ b/src/services/chains/evm/evmTransactionService.test.ts
@@ -424,4 +424,103 @@ describe('EvmTransactionService', () => {
       }
     });
   });
+
+  describe('getTransactionInfo (Account Abstraction donation handler)', () => {
+    const ENTRYPOINT_ADDRESS = '0x5ff137d4B0fdCD49dcA30c7CF57E578a026d2789';
+    const SMART_ACCOUNT = '0x501ef174B66883Ba40f92E6Fb24bfb49331D4d4C';
+    const DONOR_ADDRESS = '0x1C9B282ceC2bCc27432f1F06eE2532c88634B63F';
+    const RECIPIENT = '0xA743B5aC96F06da66Ca3921AAD06F2A2e040FB02';
+    const DONATION_HANDLER = '0x7a5D2A00a25b95fd8739bc52Cd79f8F971C37Ca1';
+    const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bDa02913';
+    const TX_HASH =
+      '0x375904913077bd62396d58781d69e51acaaa7c87ad9b5d87fd1630f20e5a113e';
+
+    it('should prefer the AA transfer sender over the donation handler log sender', async () => {
+      const amountRaw = ethers.utils.parseUnits('50.01', 6);
+      const donationLog: ethers.providers.Log = {
+        address: DONATION_HANDLER,
+        blockHash:
+          '0xabcd000000000000000000000000000000000000000000000000000000000000',
+        blockNumber: 12345,
+        data: '0x' + amountRaw.toHexString().slice(2).padStart(64, '0'),
+        logIndex: 0,
+        removed: false,
+        topics: [
+          DONATION_MADE_TOPIC,
+          '0x000000000000000000000000' + RECIPIENT.slice(2).toLowerCase(),
+          '0x000000000000000000000000' + USDC_ADDRESS.slice(2).toLowerCase(),
+        ],
+        transactionHash: TX_HASH,
+        transactionIndex: 0,
+      };
+      const transferLog: ethers.providers.Log = {
+        address: USDC_ADDRESS,
+        blockHash:
+          '0xabcd000000000000000000000000000000000000000000000000000000000000',
+        blockNumber: 12345,
+        data: '0x' + amountRaw.toHexString().slice(2).padStart(64, '0'),
+        logIndex: 1,
+        removed: false,
+        topics: [
+          TRANSFER_TOPIC,
+          '0x000000000000000000000000' + DONOR_ADDRESS.slice(2).toLowerCase(),
+          '0x000000000000000000000000' + RECIPIENT.slice(2).toLowerCase(),
+        ],
+        transactionHash: TX_HASH,
+        transactionIndex: 0,
+      };
+
+      const txResponse = {
+        hash: TX_HASH,
+        from: SMART_ACCOUNT,
+        to: ENTRYPOINT_ADDRESS,
+        value: ethers.BigNumber.from(0),
+        nonce: 10,
+        blockNumber: 12345,
+        gasPrice: ethers.BigNumber.from(1),
+      };
+      const receipt = {
+        status: 1,
+        blockNumber: 12345,
+        gasUsed: ethers.BigNumber.from(21000),
+        logs: [donationLog, transferLog],
+      };
+      const block = { timestamp: 1777305051 };
+
+      const fakeProvider = {
+        getTransaction: sinon.stub().resolves(txResponse),
+        getTransactionReceipt: sinon.stub().resolves(receipt),
+        getBlock: sinon.stub().resolves(block),
+      };
+
+      const getTokenDecimalsStub = sinon
+        .stub(evmTransactionService, 'getTokenDecimals')
+        .resolves(6);
+
+      providers.set(8453, fakeProvider);
+
+      try {
+        const result = await evmTransactionService.getTransactionInfo({
+          txHash: TX_HASH,
+          networkId: 8453,
+          symbol: 'USDC',
+          fromAddress: DONOR_ADDRESS,
+          toAddress: RECIPIENT,
+          amount: 50.01,
+          timestamp: 1777305051,
+          tokenAddress: USDC_ADDRESS,
+        });
+
+        expect(result.from.toLowerCase()).to.equal(DONOR_ADDRESS.toLowerCase());
+        expect(result.from.toLowerCase()).to.not.equal(
+          SMART_ACCOUNT.toLowerCase(),
+        );
+        expect(result.to.toLowerCase()).to.equal(RECIPIENT.toLowerCase());
+        expect(result.amount).to.equal(50.01);
+      } finally {
+        getTokenDecimalsStub.restore();
+        providers.delete(8453);
+      }
+    });
+  });
 });

--- a/src/services/chains/evm/evmTransactionService.ts
+++ b/src/services/chains/evm/evmTransactionService.ts
@@ -1235,19 +1235,6 @@ export class EvmTransactionService implements IChainHandler {
         );
       }
 
-      // Safe executions call the Safe contract as the outer tx target,
-      // so detect donation handler activity from receipt logs as well.
-      if (
-        (tx.to && isDonationHandlerAddress(networkId, tx.to)) ||
-        (receipt && this.hasDonationHandlerLog(networkId, receipt.logs))
-      ) {
-        logger.debug('Transaction is to a donation handler contract', {
-          txHash,
-          donationHandler: tx.to,
-        });
-        return this.getDonationHandlerTransactionInfo(input);
-      }
-
       if (receipt && this.isErc4337EntryPointTx(tx.to)) {
         logger.info('Detected EIP-4337 EntryPoint transaction', {
           txHash,
@@ -1275,6 +1262,19 @@ export class EvmTransactionService implements IChainHandler {
             expectedAmount: input.amount,
           },
         );
+      }
+
+      // Safe executions call the Safe contract as the outer tx target,
+      // so detect donation handler activity from receipt logs as well.
+      if (
+        (tx.to && isDonationHandlerAddress(networkId, tx.to)) ||
+        (receipt && this.hasDonationHandlerLog(networkId, receipt.logs))
+      ) {
+        logger.debug('Transaction is to a donation handler contract', {
+          txHash,
+          donationHandler: tx.to,
+        });
+        return this.getDonationHandlerTransactionInfo(input);
       }
 
       const block = receipt


### PR DESCRIPTION
## Issue

#

## Summary

Fixes Account Abstraction ERC-20 donation verification when an EntryPoint transaction also emits donation handler logs. The verifier now resolves EntryPoint transactions before the generic donation-handler path, so it validates the actual token `Transfer` sender instead of the outer AA sender.

## Changes

- Prioritized EIP-4337 EntryPoint detection before donation-handler log detection in EVM transaction verification.
- Added a Base USDC regression test matching the production failure shape, with an EntryPoint tx, donation handler event, and donor-to-project ERC-20 transfer.

## How to Test

1. Run `npm test` and expect the full suite to pass.
2. Run `npm run build` and expect TypeScript compilation to pass.
3. Run `npm run lint`; current output should exit successfully, with only existing unrelated `any` warnings in test files.
4. Verify transaction `0x375904913077bd62396d58781d69e51acaaa7c87ad9b5d87fd1630f20e5a113e` on Base with `fromAddress=0x1c9b282cec2bcc27432f1f06ee2532c88634b63f`, `toAddress=0xa743b5ac96f06da66ca3921aad06f2a2e040fb02`, `amount=50.01`, `symbol=USDC`, and token `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913`; it should resolve as successful instead of `FROM_ADDRESS_MISMATCH`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction information retrieval for Account Abstraction donations. The system now correctly prioritizes abstraction layer detection, ensuring accurate transaction details and recipient information when multiple transaction types are involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->