### PR TITLE
Fix Safe donation sender verification

### DIFF
--- a/src/services/chains/evm/evmTransactionService.test.ts
+++ b/src/services/chains/evm/evmTransactionService.test.ts
@@ -423,6 +423,76 @@ describe('EvmTransactionService', () => {
         providers.delete(100);
       }
     });
+
+    it('should infer Safe sender from outer Safe transaction target', async () => {
+      const GIV_TOKEN = '0x4f4f9b8d5b4d0dc10506e5551b0513b61fd59e75';
+      const amountRaw = ethers.utils.parseUnits('0.5', 18);
+      const donationLog: ethers.providers.Log = {
+        address: DONATION_HANDLER,
+        blockHash:
+          '0xabcd000000000000000000000000000000000000000000000000000000000000',
+        blockNumber: 12345,
+        data: '0x' + amountRaw.toHexString().slice(2).padStart(64, '0'),
+        logIndex: 0,
+        removed: false,
+        topics: [
+          DONATION_MADE_TOPIC,
+          '0x000000000000000000000000' + RECIPIENT.slice(2).toLowerCase(),
+          '0x000000000000000000000000' + GIV_TOKEN.slice(2).toLowerCase(),
+        ],
+        transactionHash: TX_HASH,
+        transactionIndex: 0,
+      };
+
+      const txResponse = {
+        hash: TX_HASH,
+        from: EXECUTOR_ADDRESS,
+        to: SAFE_ADDRESS,
+        value: ethers.BigNumber.from(0),
+        nonce: 7,
+        blockNumber: 12345,
+        gasPrice: ethers.BigNumber.from(1),
+      };
+      const receipt = {
+        status: 1,
+        blockNumber: 12345,
+        gasUsed: ethers.BigNumber.from(21000),
+        logs: [donationLog],
+      };
+      const block = { timestamp: 1600000000 };
+
+      const fakeProvider = {
+        getTransaction: sinon.stub().resolves(txResponse),
+        getTransactionReceipt: sinon.stub().resolves(receipt),
+        getBlock: sinon.stub().resolves(block),
+      };
+
+      const getTokenDecimalsStub = sinon
+        .stub(evmTransactionService, 'getTokenDecimals')
+        .resolves(18);
+
+      providers.set(100, fakeProvider);
+
+      try {
+        const result = await evmTransactionService.getTransactionInfo({
+          txHash: TX_HASH,
+          networkId: 100,
+          symbol: 'GIV',
+          fromAddress: SAFE_ADDRESS,
+          toAddress: RECIPIENT,
+          amount: 0.5,
+          timestamp: 1600000000,
+          tokenAddress: GIV_TOKEN,
+        });
+
+        expect(result.from).to.equal(SAFE_ADDRESS);
+        expect(result.to).to.equal(RECIPIENT);
+        expect(result.amount).to.equal(0.5);
+      } finally {
+        getTokenDecimalsStub.restore();
+        providers.delete(100);
+      }
+    });
   });
 
   describe('getTransactionInfo (Account Abstraction donation handler)', () => {

--- a/src/services/chains/evm/evmTransactionService.ts
+++ b/src/services/chains/evm/evmTransactionService.ts
@@ -702,14 +702,19 @@ export class EvmTransactionService implements IChainHandler {
     receipt: ethers.providers.TransactionReceipt,
   ): string {
     const txTo = tx.to ? normalizeAddress(tx.to) : null;
+    const expectedFrom = normalizeAddress(input.fromAddress);
+    const hasDonationHandlerLog = this.hasDonationHandlerLog(
+      input.networkId,
+      receipt.logs,
+    );
 
     // Safe executions submit the outer transaction to the Safe contract,
     // while the donation handler call happens internally and emits logs.
     if (
-      input.safeTxHash &&
       txTo &&
-      !isDonationHandlerAddress(input.networkId, txTo) &&
-      this.hasDonationHandlerLog(input.networkId, receipt.logs)
+      hasDonationHandlerLog &&
+      ((input.safeTxHash && !isDonationHandlerAddress(input.networkId, txTo)) ||
+        txTo === expectedFrom)
     ) {
       return tx.to!;
     }


### PR DESCRIPTION
## Issue

#

## Summary

Safe donation handler transactions can be executed by an EOA while the Safe contract is the actual donor. This PR fixes verification so successful Safe donations are attributed to the Safe address instead of the executor address, preventing valid donations from being marked failed.

## Changes

- Infer the Safe sender from the outer transaction target when donation handler logs are present and the expected donor matches that target.
- Preserve existing donation handler behavior for direct handler calls and Safe transactions that provide `safeTxHash`.
- Add a regression test for the Gnosis Safe `execTransaction` -> MultiSend -> donation handler flow with GIV ERC-20 transfers.

## How to Test

1. Run `npm test` and confirm the suite passes.
2. Run `npm run lint` and confirm there are no errors.
3. Verify the reported Gnosis transaction through `/verify` with network `100`, symbol `GIV`, from address `0xe08187A3C051B6136bD4C652553E5fEeE0d6038d`, token address `0x4f4f9b8d5b4d0dc10506e5551B0513B61fD59e75`, and each recipient/amount from the transaction. The response should be valid instead of `FROM_ADDRESS_MISMATCH`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sender address detection for Safe wallet donation transactions to ensure accurate transaction attribution.

* **Tests**
  * Added test coverage for Safe wallet donation transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->