### PR TITLE
Fix sponsored donation verification

### DIFF
--- a/src/services/chains/evm/evmTransactionService.test.ts
+++ b/src/services/chains/evm/evmTransactionService.test.ts
@@ -495,6 +495,110 @@ describe('EvmTransactionService', () => {
     });
   });
 
+  describe('getTransactionInfo (sponsored donation handler)', () => {
+    const RELAYER_ADDRESS = '0xB42F812A44c22cc6b861478900401ee759EbEAD6';
+    const DONOR_ADDRESS = '0x65279542f9312620a67469b042a8bb6851904442';
+    const RECIPIENT = '0x4d9339dd97db55e3b9bcbe65de39ff9c04d1c2cd';
+    const DONATION_HANDLER = '0x6e349C56F512cB4250276BF36335c8dd618944A1';
+    const USDC_ADDRESS = '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359';
+    const TX_HASH =
+      '0xf2f47c7c977933f08e57c13323b3f53d5ab65e6e132f626b9aba9ae635532f76';
+
+    it('should attribute ERC-20 donation handler events to the funding transfer sender', async () => {
+      const donationAmountRaw = ethers.utils.parseUnits('1', 6);
+      const fundingAmountRaw = ethers.utils.parseUnits('11', 6);
+      const donationLog: ethers.providers.Log = {
+        address: DONATION_HANDLER,
+        blockHash:
+          '0xabcd000000000000000000000000000000000000000000000000000000000000',
+        blockNumber: 12345,
+        data: '0x' + donationAmountRaw.toHexString().slice(2).padStart(64, '0'),
+        logIndex: 0,
+        removed: false,
+        topics: [
+          DONATION_MADE_TOPIC,
+          '0x000000000000000000000000' + RECIPIENT.slice(2).toLowerCase(),
+          '0x000000000000000000000000' + USDC_ADDRESS.slice(2).toLowerCase(),
+        ],
+        transactionHash: TX_HASH,
+        transactionIndex: 0,
+      };
+      const fundingTransferLog: ethers.providers.Log = {
+        address: USDC_ADDRESS,
+        blockHash:
+          '0xabcd000000000000000000000000000000000000000000000000000000000000',
+        blockNumber: 12345,
+        data: '0x' + fundingAmountRaw.toHexString().slice(2).padStart(64, '0'),
+        logIndex: 1,
+        removed: false,
+        topics: [
+          TRANSFER_TOPIC,
+          '0x000000000000000000000000' + DONOR_ADDRESS.slice(2).toLowerCase(),
+          '0x000000000000000000000000' +
+            DONATION_HANDLER.slice(2).toLowerCase(),
+        ],
+        transactionHash: TX_HASH,
+        transactionIndex: 0,
+      };
+
+      const txResponse = {
+        hash: TX_HASH,
+        from: RELAYER_ADDRESS,
+        to: DONATION_HANDLER,
+        value: ethers.BigNumber.from(0),
+        nonce: 10,
+        blockNumber: 12345,
+        gasPrice: ethers.BigNumber.from(1),
+      };
+      const receipt = {
+        status: 1,
+        blockNumber: 12345,
+        gasUsed: ethers.BigNumber.from(21000),
+        logs: [donationLog, fundingTransferLog],
+      };
+      const block = { timestamp: 1777305051 };
+
+      const fakeProvider = {
+        getTransaction: sinon.stub().resolves(txResponse),
+        getTransactionReceipt: sinon.stub().resolves(receipt),
+        getBlock: sinon.stub().resolves(block),
+      };
+
+      const getTokenDecimalsStub = sinon
+        .stub(evmTransactionService, 'getTokenDecimals')
+        .resolves(6);
+      const getTokenSymbolStub = sinon
+        .stub(evmTransactionService, 'getTokenSymbol')
+        .resolves('USDC');
+
+      providers.set(137, fakeProvider);
+
+      try {
+        const result = await evmTransactionService.getTransactionInfo({
+          txHash: TX_HASH,
+          networkId: 137,
+          symbol: 'USDC',
+          fromAddress: DONOR_ADDRESS,
+          toAddress: RECIPIENT,
+          amount: 1,
+          timestamp: 1777305051,
+          tokenAddress: USDC_ADDRESS,
+        });
+
+        expect(result.from.toLowerCase()).to.equal(DONOR_ADDRESS.toLowerCase());
+        expect(result.from.toLowerCase()).to.not.equal(
+          RELAYER_ADDRESS.toLowerCase(),
+        );
+        expect(result.to.toLowerCase()).to.equal(RECIPIENT.toLowerCase());
+        expect(result.amount).to.equal(1);
+      } finally {
+        getTokenDecimalsStub.restore();
+        getTokenSymbolStub.restore();
+        providers.delete(137);
+      }
+    });
+  });
+
   describe('getTransactionInfo (Account Abstraction donation handler)', () => {
     const ENTRYPOINT_ADDRESS = '0x5ff137d4B0fdCD49dcA30c7CF57E578a026d2789';
     const SMART_ACCOUNT = '0x501ef174B66883Ba40f92E6Fb24bfb49331D4d4C';

--- a/src/services/chains/evm/evmTransactionService.ts
+++ b/src/services/chains/evm/evmTransactionService.ts
@@ -722,6 +722,46 @@ export class EvmTransactionService implements IChainHandler {
     return tx.from;
   }
 
+  private inferErc20DonationSenderFromFundingTransfer(params: {
+    receipt: ethers.providers.TransactionReceipt;
+    networkId: number;
+    tokenAddress: string;
+    expectedFrom: string;
+    expectedAmount: number;
+    tokenDecimals: number;
+  }): string | null {
+    const {
+      receipt,
+      networkId,
+      tokenAddress,
+      expectedFrom,
+      expectedAmount,
+      tokenDecimals,
+    } = params;
+    const normalizedExpectedFrom = normalizeAddress(expectedFrom);
+    const normalizedTokenAddress = normalizeAddress(tokenAddress);
+    const handlerAddresses = new Set(
+      getDonationHandlerAddresses(networkId).map((address) =>
+        normalizeAddress(address),
+      ),
+    );
+    const expectedAmountRaw = BigInt(
+      ethers.utils
+        .parseUnits(expectedAmount.toString(), tokenDecimals)
+        .toString(),
+    );
+
+    const fundingTransfer = this.parseTransferEvents(receipt.logs).find(
+      (transfer) =>
+        normalizeAddress(transfer.from) === normalizedExpectedFrom &&
+        handlerAddresses.has(normalizeAddress(transfer.to)) &&
+        normalizeAddress(transfer.tokenAddress) === normalizedTokenAddress &&
+        transfer.amount >= expectedAmountRaw,
+    );
+
+    return fundingTransfer ? fundingTransfer.from : null;
+  }
+
   /**
    * Parse DonationMade events from transaction logs
    * Used for both ERC-20 and native token donations through donation handler
@@ -1039,6 +1079,34 @@ export class EvmTransactionService implements IChainHandler {
         amount,
         erc20TokenDecimals,
       );
+
+      if (donationTransfer) {
+        const inferredSender = this.inferErc20DonationSenderFromFundingTransfer(
+          {
+            receipt,
+            networkId,
+            tokenAddress: tokenAddress!,
+            expectedFrom: input.fromAddress,
+            expectedAmount: amount,
+            tokenDecimals: erc20TokenDecimals,
+          },
+        );
+
+        if (inferredSender) {
+          logger.debug(
+            'Inferred ERC-20 donation sender from funding transfer',
+            {
+              txHash,
+              donationEventSender: donationTransfer.from,
+              inferredSender,
+            },
+          );
+          donationTransfer = {
+            ...donationTransfer,
+            from: inferredSender,
+          };
+        }
+      }
 
       // If not found in DonationMade events, try Transfer events
       if (!donationTransfer) {

--- a/src/services/priceService.test.ts
+++ b/src/services/priceService.test.ts
@@ -141,6 +141,45 @@ describe('PriceService - fixed-price overrides', () => {
     expect(axiosGetStub.calledOnce).to.be.true;
   });
 
+  it('shares native symbol prices across networks to avoid duplicate CoinGecko calls', async () => {
+    axiosGetStub.resolves({
+      data: { ethereum: { usd: 2500 } },
+    });
+
+    const mainnetPrice = await priceService.getTokenPrice({
+      networkId: 1,
+      symbol: 'ETH',
+    });
+    const optimismPrice = await priceService.getTokenPrice({
+      networkId: 10,
+      symbol: 'ETH',
+    });
+
+    expect(mainnetPrice).to.equal(2500);
+    expect(optimismPrice).to.equal(2500);
+    expect(axiosGetStub.calledOnce).to.be.true;
+  });
+
+  it('uses stale cached native prices when CoinGecko is temporarily unavailable', async () => {
+    const cache = (
+      priceService as unknown as {
+        priceCache: Map<string, { price: number; timestamp: number }>;
+      }
+    ).priceCache;
+    cache.set('symbol:ETH', {
+      price: 2500,
+      timestamp: Date.now() - 120_000,
+    });
+    axiosGetStub.rejects(new Error('Request failed with status code 429'));
+
+    const price = await priceService.getTokenPrice({
+      networkId: 10,
+      symbol: 'ETH',
+    });
+
+    expect(price).to.equal(2500);
+  });
+
   it('returns a hardcoded $1 USD price for TIK on mainnet', async () => {
     const price = await priceService.getTokenPrice({
       networkId: 1,

--- a/src/services/priceService.ts
+++ b/src/services/priceService.ts
@@ -64,7 +64,11 @@ export class PriceService {
     symbol: string,
     tokenAddress?: string | null,
   ): string {
-    return `${networkId}:${symbol}:${tokenAddress || 'native'}`;
+    if (!tokenAddress) {
+      return `symbol:${symbol.toUpperCase()}`;
+    }
+
+    return `${networkId}:${symbol.toUpperCase()}:${tokenAddress.toLowerCase()}`;
   }
 
   private getCachedPrice(
@@ -72,14 +76,22 @@ export class PriceService {
     symbol: string,
     tokenAddress?: string | null,
   ): number | null {
-    const key = this.getCacheKey(networkId, symbol, tokenAddress);
-    const cached = this.priceCache.get(key);
+    const cached = this.getCachedPriceEntry(networkId, symbol, tokenAddress);
 
     if (cached && Date.now() - cached.timestamp < this.cacheTtlMs) {
       return cached.price;
     }
 
     return null;
+  }
+
+  private getCachedPriceEntry(
+    networkId: number,
+    symbol: string,
+    tokenAddress?: string | null,
+  ): { price: number; timestamp: number } | null {
+    const key = this.getCacheKey(networkId, symbol, tokenAddress);
+    return this.priceCache.get(key) ?? null;
   }
 
   private setCachedPrice(
@@ -132,6 +144,22 @@ export class PriceService {
       logger.debug('Token price fetched', { symbol, price });
       return price;
     } catch (error) {
+      const staleCachedPrice = this.getCachedPriceEntry(
+        networkId,
+        symbol,
+        tokenAddress,
+      );
+      if (staleCachedPrice) {
+        logger.warn('Using stale cached token price after fetch failure', {
+          networkId,
+          symbol,
+          tokenAddress,
+          price: staleCachedPrice.price,
+          ageMs: Date.now() - staleCachedPrice.timestamp,
+        });
+        return staleCachedPrice.price;
+      }
+
       logger.error('Failed to fetch token price', {
         error: error instanceof Error ? error.message : 'Unknown error',
         networkId,


### PR DESCRIPTION
## Summary
- Attributes sponsored ERC-20 donation-handler transactions to the donor funding transfer instead of the relayer transaction sender.
- Reuses cached native-token prices across networks and falls back to stale cached prices during transient CoinGecko failures.

## Test plan
- `npm test -- --grep "PriceService|EvmTransactionService"`

## Notes
- The same fix has been cherry-picked and pushed to `staging` as `95cb8ed`.

Made with [Cursor](https://cursor.com)