### PR TITLE
Hotfix: update Polygon donation handler allowlist

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -490,7 +490,7 @@ To add support for new donation handler contracts, update the configuration in `
 ```typescript
 export const DONATION_HANDLER_ADDRESSES: Record<number, string[]> = {
   [NetworkId.POLYGON]: [
-    '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b', // Existing handler
+    '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b', // Active handler
     '0x6e349C56F512cB4250276BF36335c8dd618944A1', // Legacy handler, no longer used by FE
     '0xNEW_HANDLER_ADDRESS', // Add new handlers here
   ],

--- a/docs/API.md
+++ b/docs/API.md
@@ -458,7 +458,8 @@ The service supports verifying donations made through donation handler contracts
 
 | Network | Contract Address |
 |---------|-----------------|
-| Polygon | `0x6e349C56F512cB4250276BF36335c8dd618944A1` |
+| Polygon | `0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b` |
+| Polygon (legacy verification only) | `0x6e349C56F512cB4250276BF36335c8dd618944A1` |
 
 ### How It Works
 
@@ -489,7 +490,8 @@ To add support for new donation handler contracts, update the configuration in `
 ```typescript
 export const DONATION_HANDLER_ADDRESSES: Record<number, string[]> = {
   [NetworkId.POLYGON]: [
-    '0x6e349C56F512cB4250276BF36335c8dd618944A1', // Existing handler
+    '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b', // Existing handler
+    '0x6e349C56F512cB4250276BF36335c8dd618944A1', // Legacy handler, no longer used by FE
     '0xNEW_HANDLER_ADDRESS', // Add new handlers here
   ],
   [NetworkId.MAINNET]: [

--- a/src/config/donationHandlers.test.ts
+++ b/src/config/donationHandlers.test.ts
@@ -13,6 +13,9 @@ describe('Donation Handlers Config', () => {
       expect(polygonHandlers).to.be.an('array');
       expect(polygonHandlers.length).to.be.greaterThan(0);
       expect(polygonHandlers).to.include(
+        '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b',
+      );
+      expect(polygonHandlers).to.include(
         '0x6e349C56F512cB4250276BF36335c8dd618944A1',
       );
     });
@@ -22,7 +25,7 @@ describe('Donation Handlers Config', () => {
     it('should return true for known donation handler on Polygon', () => {
       const result = isDonationHandlerAddress(
         NetworkId.POLYGON,
-        '0x6e349C56F512cB4250276BF36335c8dd618944A1',
+        '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b',
       );
       expect(result).to.be.true;
     });
@@ -30,15 +33,23 @@ describe('Donation Handlers Config', () => {
     it('should be case-insensitive', () => {
       const resultLower = isDonationHandlerAddress(
         NetworkId.POLYGON,
-        '0x6e349c56f512cb4250276bf36335c8dd618944a1',
+        '0x4102e15f4621fc45fce8e07442a702bd49fcea4b',
       );
       const resultUpper = isDonationHandlerAddress(
         NetworkId.POLYGON,
-        '0x6E349C56F512CB4250276BF36335C8DD618944A1',
+        '0x4102E15F4621FC45FCE8E07442A702BD49FCEA4B',
       );
 
       expect(resultLower).to.be.true;
       expect(resultUpper).to.be.true;
+    });
+
+    it('should keep accepting the legacy Polygon handler', () => {
+      const result = isDonationHandlerAddress(
+        NetworkId.POLYGON,
+        '0x6e349C56F512cB4250276BF36335c8dd618944A1',
+      );
+      expect(result).to.be.true;
     });
 
     it('should return false for unknown addresses', () => {
@@ -52,7 +63,7 @@ describe('Donation Handlers Config', () => {
     it('should return false for unsupported networks', () => {
       const result = isDonationHandlerAddress(
         999999,
-        '0x6e349C56F512cB4250276BF36335c8dd618944A1',
+        '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b',
       );
       expect(result).to.be.false;
     });

--- a/src/config/donationHandlers.ts
+++ b/src/config/donationHandlers.ts
@@ -9,7 +9,10 @@ export const DONATION_HANDLER_ADDRESSES: Record<number, string[]> = {
     '0x97b2cb568e0880B99Cd16EFc6edFF5272Aa02676', // Giveth Donation Handler on Ethereum Mainnet
   ],
   [NetworkId.POLYGON]: [
-    '0x6e349C56F512cB4250276BF36335c8dd618944A1', // Giveth Donation Handler on Polygon
+    '0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b', // Giveth Donation Handler on Polygon
+    // Legacy Polygon handler kept for verifying historical donations.
+    // The frontend no longer sends new donations to this address.
+    '0x6e349C56F512cB4250276BF36335c8dd618944A1',
   ],
   [NetworkId.OPTIMISM]: [
     '0x8D685A56C51Cf54685d3dB0Ea50748D3A2c2e0dC', // Giveth Donation Handler on Optimism


### PR DESCRIPTION
## Issue

#

## Summary

Production hotfix to recognize the new Polygon donation handler in the blockchain service while preserving the legacy handler for historical verification. The legacy address is documented as no longer used by the frontend.

## Changes

- Added the new Polygon donation handler address to the backend allowlist.
- Kept the old Polygon handler as legacy verification-only support with an inline note.
- Updated handler config tests and API docs for both active and legacy Polygon handlers.

## How to Test

1. Run `npm test -- --grep "Donation Handlers Config"`.
2. Run `npx eslint src/config/donationHandlers.ts src/config/donationHandlers.test.ts`.
3. Verify Polygon donations sent to `0x4102E15f4621Fc45fCe8E07442A702BD49fcea4b` are recognized as donation handler transactions.
4. Verify historical Polygon donations sent to `0x6e349C56F512cB4250276BF36335c8dd618944A1` remain verifiable.

Made with [Cursor](https://cursor.com)