### PR TITLE
Hotfix: handle extra fractional token digits in verification

### DIFF
--- a/src/services/chains/evm/evmTransactionService.test.ts
+++ b/src/services/chains/evm/evmTransactionService.test.ts
@@ -222,6 +222,35 @@ describe('EvmTransactionService', () => {
       expect(result!.amount).to.equal(BigInt('1250000'));
     });
 
+    it('should match when expected amount has more fractional digits than token decimals', () => {
+      const usdcTransfers: DonationTransferInfo[] = [
+        {
+          from: '0x214ED6e90C8BE22B6091775c1AA870Ac8CA1CBe3',
+          to: '0xd7095B0618609feF9e542D5A1D320502C8544D10',
+          amount: BigInt('5050343'), // 5.050343 USDC
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          isNativeToken: false,
+        },
+        {
+          from: '0x214ED6e90C8BE22B6091775c1AA870Ac8CA1CBe3',
+          to: '0xd7095B0618609feF9e542D5A1D320502C8544D10',
+          amount: BigInt('10000000'), // 10 USDC
+          tokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          isNativeToken: false,
+        },
+      ];
+
+      const result = evmTransactionService.findDonationTransfer(
+        usdcTransfers,
+        '0xd7095B0618609feF9e542D5A1D320502C8544D10',
+        5.050343423352787,
+        6,
+      );
+
+      expect(result).to.not.be.null;
+      expect(result!.amount).to.equal(BigInt('5050343'));
+    });
+
     it('should not use 18 decimals for 6-decimal token (wrong decimals pick wrong transfer)', () => {
       // Two USDC transfers. With 6 decimals, expected 100 matches 100 USDC. With 18 decimals, no match so first is returned.
       const usdcTransfers: DonationTransferInfo[] = [

--- a/src/services/chains/evm/evmTransactionService.ts
+++ b/src/services/chains/evm/evmTransactionService.ts
@@ -66,6 +66,35 @@ export interface DonationTransferInfo {
 export class EvmTransactionService implements IChainHandler {
   private providers: Map<number, ethers.providers.JsonRpcProvider> = new Map();
 
+  private formatAmountForTokenDecimals(
+    amount: number,
+    tokenDecimals: number,
+  ): string {
+    if (!Number.isFinite(amount)) {
+      throw new Error(`Invalid token amount: ${amount}`);
+    }
+
+    const fractionDigits = Math.min(Math.max(tokenDecimals + 12, 20), 100);
+    const [whole, fraction = ''] = amount.toFixed(fractionDigits).split('.');
+    const clampedFraction = fraction.slice(0, tokenDecimals).replace(/0+$/, '');
+
+    return clampedFraction ? `${whole}.${clampedFraction}` : whole;
+  }
+
+  private parseExpectedAmountRaw(
+    expectedAmount: number,
+    tokenDecimals: number,
+  ): bigint {
+    return BigInt(
+      ethers.utils
+        .parseUnits(
+          this.formatAmountForTokenDecimals(expectedAmount, tokenDecimals),
+          tokenDecimals,
+        )
+        .toString(),
+    );
+  }
+
   isSupported(networkId: number): boolean {
     try {
       return getChainType(networkId) === ChainType.EVM;
@@ -745,10 +774,9 @@ export class EvmTransactionService implements IChainHandler {
         normalizeAddress(address),
       ),
     );
-    const expectedAmountRaw = BigInt(
-      ethers.utils
-        .parseUnits(expectedAmount.toString(), tokenDecimals)
-        .toString(),
+    const expectedAmountRaw = this.parseExpectedAmountRaw(
+      expectedAmount,
+      tokenDecimals,
     );
 
     const fundingTransfer = this.parseTransferEvents(receipt.logs).find(
@@ -843,10 +871,9 @@ export class EvmTransactionService implements IChainHandler {
 
     // If multiple transfers and we have an expected amount, find the closest match
     if (expectedAmount !== undefined) {
-      const expectedAmountBigInt = BigInt(
-        ethers.utils
-          .parseUnits(expectedAmount.toString(), tokenDecimals)
-          .toString(),
+      const expectedAmountBigInt = this.parseExpectedAmountRaw(
+        expectedAmount,
+        tokenDecimals,
       );
 
       // Find transfer with closest amount (within 1% tolerance)


### PR DESCRIPTION
## Issue

N/A - production hotfix

## Summary

Production verification for USDC donation-handler transactions was failing with `NUMERIC_FAULT underflow` when the expected amount had more fractional digits than the token supports. This hotfix clamps expected token amounts to the token decimal precision before converting with `parseUnits`, allowing normal transfer matching and amount validation to proceed.

## Changes

- Added a helper to format expected token amounts according to token decimals before `parseUnits`.
- Reused that helper for donation transfer matching and ERC-20 funding-transfer sender inference.
- Added regression coverage for the production-style USDC amount `5.050343423352787` against a 6-decimal token.

## How to Test

1. Verify a USDC donation-handler transaction whose submitted expected amount has more than 6 fractional digits and confirm verification no longer throws `fractional component exceeds decimals`.
2. Run `npm test -- --grep "EvmTransactionService"`.
3. Run `npm run build`.
4. Run `npx eslint src/services/chains/evm/evmTransactionService.ts src/services/chains/evm/evmTransactionService.test.ts`.
